### PR TITLE
Fix product image saving on update

### DIFF
--- a/backend-ferreteria/src/controllers/admin/adminController.js
+++ b/backend-ferreteria/src/controllers/admin/adminController.js
@@ -47,23 +47,24 @@ exports.subirImagenProducto = async (req, res) => {
   try {
     const idProducto = req.params.idProducto;
 
-    // Validar archivo
     if (!req.file) {
       return res.status(400).json({ error: 'No se envió ninguna imagen' });
     }
 
-    // Borra imágenes anteriores en la carpeta (menos la recién subida)
-    const carpetaProducto = path.join(__dirname, '../../../uploads/productos/', idProducto.toString());
-    const archivos = fs.readdirSync(carpetaProducto).filter(f => f !== req.file.filename);
+    const carpetaProducto = path.resolve(__dirname, '../../../uploads/productos', idProducto.toString());
+    await fs.ensureDir(carpetaProducto);
+
+    const archivos = await fs.readdir(carpetaProducto);
     for (const file of archivos) {
-      fs.unlinkSync(path.join(carpetaProducto, file));
+      if (file !== req.file.filename) {
+        await fs.unlink(path.join(carpetaProducto, file));
+      }
     }
 
-    // Guarda la ruta de la nueva imagen en la BD
     const rutaImagen = `/uploads/productos/${idProducto}/${req.file.filename}`;
     await productoModel.actualizarRutaImagen(idProducto, rutaImagen);
 
-    return res.json({ mensaje: 'Imagen subida correctamente', ruta: rutaImagen });
+    return res.json({ message: 'Imagen subida y asociada correctamente', path: rutaImagen });
   } catch (error) {
     console.error('Error al subir imagen:', error);
     res.status(500).json({ error: 'Error interno al subir la imagen' });

--- a/backend-ferreteria/src/routes/admin/adminRoutes.js
+++ b/backend-ferreteria/src/routes/admin/adminRoutes.js
@@ -9,13 +9,12 @@ const multer = require('multer');
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     const idProducto = req.params.idProducto;
-    const dir = path.join(__dirname, '../../../uploads/productos/', idProducto);
+    const dir = path.resolve(__dirname, '../../../uploads/productos', idProducto);
     // Crea la carpeta si no existe
     fs.mkdirSync(dir, { recursive: true });
     cb(null, dir);
   },
   filename: function (req, file, cb) {
-    // Le puedes poner un nombre único usando Date.now() o mantener el nombre original
     const ext = path.extname(file.originalname);
     const nombre = Date.now() + ext;
     cb(null, nombre);


### PR DESCRIPTION
## Summary
- use `path.resolve` for consistent upload directory
- remove old image files asynchronously and ensure dir exists
- standardize the API response when uploading a product image

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874815326d48332959e05eea5351df4