### PR TITLE
Add missing error cases in profile and user controller tests

### DIFF
--- a/backend-ferreteria/src/test/controllers/perfilController.test.js
+++ b/backend-ferreteria/src/test/controllers/perfilController.test.js
@@ -2,12 +2,14 @@
 
 const request = require('supertest');
 const express = require('express');
+const multer = require('multer');
 const perfilController = require('../../../src/controllers/perfilController');
 const perfilModel = require('../../../src/models/PerfilModel');
 
 // Mock de Express y rutas
 const app = express();
 app.use(express.json());
+const upload = multer({ storage: multer.memoryStorage() });
 
 // Middleware falso para simular autenticación
 app.use((req, res, next) => {
@@ -20,6 +22,8 @@ jest.mock('../../../src/models/PerfilModel');
 app.get('/perfil', perfilController.getPerfilUsuario);
 app.get('/usuarios', perfilController.getTodosLosUsuarios);
 app.get('/perfil/:id', perfilController.getPerfilPorId);
+app.post('/perfil/foto', upload.single('imagen'), perfilController.actualizarFotoPerfil);
+app.post('/perfil/portada', upload.single('imagen'), perfilController.actualizarPortada);
 
 describe('perfilController', () => {
   afterEach(() => {
@@ -80,7 +84,7 @@ describe('perfilController', () => {
   test('GET /perfil/:id - perfil no encontrado por ID', async () => {
     perfilModel.obtenerPerfilPorId.mockResolvedValue(null);
 
-    const response = await request(app).get('/perfil/999');
+    const response = await request(app).get('/perfil/60');
     expect(response.status).toBe(404);
     expect(response.body.error).toBe("Usuario no encontrado");
   });
@@ -91,5 +95,85 @@ describe('perfilController', () => {
     const response = await request(app).get('/perfil/2');
     expect(response.status).toBe(500);
     expect(response.body.error).toBe("Error en el servidor");
+  });
+
+  describe('POST /perfil/foto', () => {
+    test('actualiza la foto de perfil correctamente', async () => {
+      perfilModel.actualizarImagen.mockResolvedValue({ message: 'Perfil actualizada con éxito' });
+
+      const res = await request(app)
+        .post('/perfil/foto')
+        .field('rut', '12345678-9')
+        .attach('imagen', Buffer.from('img'), 'avatar.jpg');
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toMatch(/Perfil actualizada/);
+    });
+
+    test('retorna 400 si no se adjunta archivo', async () => {
+      const res = await request(app)
+        .post('/perfil/foto')
+        .field('rut', '12345678-9');
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('No se ha subido ningún archivo.');
+    });
+
+    test('retorna 403 si el rut no coincide', async () => {
+      const res = await request(app)
+        .post('/perfil/foto')
+        .field('rut', '11-1')
+        .attach('imagen', Buffer.from('img'), 'avatar.jpg');
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('No autorizado');
+    });
+
+    test('retorna 500 si falla el modelo', async () => {
+      perfilModel.actualizarImagen.mockRejectedValue(new Error('fail'));
+
+      const res = await request(app)
+        .post('/perfil/foto')
+        .field('rut', '12345678-9')
+        .attach('imagen', Buffer.from('img'), 'avatar.jpg');
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('Error al actualizar la imagen de perfil');
+    });
+  });
+
+  describe('POST /perfil/portada', () => {
+    test('actualiza la portada correctamente', async () => {
+      perfilModel.actualizarImagen.mockResolvedValue({ message: 'Portada actualizada con éxito' });
+
+      const res = await request(app)
+        .post('/perfil/portada')
+        .field('rut', '12345678-9')
+        .attach('imagen', Buffer.from('img'), 'portada.jpg');
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toMatch(/Portada actualizada/);
+    });
+
+    test('retorna 400 si no se adjunta archivo', async () => {
+      const res = await request(app)
+        .post('/perfil/portada')
+        .field('rut', '12345678-9');
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('No se ha subido ningún archivo.');
+    });
+
+    test('retorna 500 si el modelo falla', async () => {
+      perfilModel.actualizarImagen.mockRejectedValue(new Error('fail'));
+
+      const res = await request(app)
+        .post('/perfil/portada')
+        .field('rut', '12345678-9')
+        .attach('imagen', Buffer.from('img'), 'portada.jpg');
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('Error al actualizar la imagen de portada');
+    });
   });
 });

--- a/backend-ferreteria/src/test/controllers/userController.test.js
+++ b/backend-ferreteria/src/test/controllers/userController.test.js
@@ -1,5 +1,6 @@
 const request = require('supertest');
 const express = require('express');
+const jwt = require('jsonwebtoken');
 // Mock del modelo para evitar llamadas reales a la BD en tests unitarios
 jest.mock('../../../src/models/UserModel'); 
 const userModel = require('../../../src/models/UserModel');
@@ -7,6 +8,7 @@ const userController = require('../../../src/controllers/userController');
 
 const app = express();
 app.use(express.json());
+process.env.JWT_SECRET = 'secret';
 
 app.post('/register', userController.register);
 app.post('/login', userController.login);
@@ -39,6 +41,42 @@ describe('userController', () => {
       expect(response.body).toHaveProperty('id_usuario');
       expect(response.body.email).toBe(userData.email);
     });
+
+    test('retorna 400 si faltan email o password', async () => {
+      const res = await request(app).post('/register').send({ nombre: 'SinEmail' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/correo y contrase\u00f1a/i);
+    });
+
+    test('retorna 400 si el email ya existe', async () => {
+      userModel.register.mockResolvedValue({ status: 400, body: { error: 'El correo ya est\u00e1 registrado' } });
+
+      const data = { nombre: 'Juan', email: 'existe@dominio.com', password: '123456', rut: '11-1', tipo_usuario_id: 1, genero_id: 1 };
+
+      const res = await request(app).post('/register').send(data);
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/correo ya est\u00e1 registrado/i);
+    });
+
+    test('retorna 400 si el RUT ya existe', async () => {
+      userModel.register.mockResolvedValue({ status: 400, body: { error: 'El RUT ya est\u00e1 registrado' } });
+      const data = { nombre: 'Juan', email: 'nuevo@dominio.com', password: '123456', rut: '11-1', tipo_usuario_id: 1, genero_id: 1 };
+
+      const res = await request(app).post('/register').send(data);
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/RUT ya est\u00e1 registrado/i);
+    });
+
+    test('retorna 500 si ocurre un error en el servidor', async () => {
+      userModel.register.mockRejectedValue(new Error('fail'));
+
+      const data = { nombre: 'Juan', email: 'a@b.com', password: '123456', rut: '12-3', tipo_usuario_id: 1, genero_id: 1 };
+      const res = await request(app).post('/register').send(data);
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toMatch(/interno al registrar el usuario/i);
+    });
   });
 
   describe('CU01 – Login de usuario', () => {
@@ -60,18 +98,58 @@ describe('userController', () => {
       expect(response.status).toBe(200);
       expect(response.body).toHaveProperty('token');
     });
+
+    test('retorna 401 cuando las credenciales son incorrectas', async () => {
+      userModel.login.mockResolvedValue({ status: 401, body: { error: 'Correo o contrase\u00f1a incorrectos' } });
+      const res = await request(app).post('/login').send({ email: 'a@b.com', password: 'bad' });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toMatch(/incorrectos/);
+    });
+
+    test('retorna 400 si faltan datos', async () => {
+      const res = await request(app).post('/login').send({ email: 'a@b.com' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/obligatorios/);
+    });
+
+    test('retorna 500 si ocurre un error en el servidor', async () => {
+      userModel.login.mockRejectedValue(new Error('db fail'));
+      const res = await request(app).post('/login').send({ email: 'a@b.com', password: '123456' });
+      expect(res.status).toBe(500);
+      expect(res.body.error).toMatch(/servidor/);
+    });
   });
 
   describe('CU02 – Logout de usuario', () => {
     test('debe cerrar sesión correctamente con token válido', async () => {
-      const token = 'un-token-jwt-valido'; 
+      const token = 'un-token-jwt-valido';
+      jest.spyOn(jwt, 'verify').mockReturnValue({ exp: Date.now() / 1000 + 60 });
+      userModel.invalidateToken.mockResolvedValue();
 
       const response = await request(app)
         .post('/logout')
         .set('Authorization', `Bearer ${token}`);
 
       expect(response.status).toBe(200);
-      expect(response.body).toEqual({ message: 'Logout exitoso' });
+      expect(response.body).toEqual({ message: 'Sesión cerrada correctamente' });
+    });
+
+    test('retorna 400 si el token es inválido', async () => {
+      jest.spyOn(jwt, 'verify').mockImplementation(() => { throw new Error('bad'); });
+      const response = await request(app)
+        .post('/logout')
+        .set('Authorization', 'Bearer invalido');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Token no válido.');
+    });
+
+    test('retorna 401 si no se envía token', async () => {
+      const response = await request(app).post('/logout');
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('No se proporcionó token.');
     });
   });
 });


### PR DESCRIPTION
## Summary
- extend profile controller tests for portada error handling
- add logout test when Authorization token is missing

## Testing
- `npm install` *(fails: internet restricted)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875993d86308321bbf3e2ddb8543534